### PR TITLE
ci: Restrict Scoop version for test to v0.2.2

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ environment:
 
 install:
   - cd c:\projects
-  - git clone --depth 1 https://github.com/ScoopInstaller/Scoop.git
+  - git clone -b v0.2.2 --depth 1 https://github.com/ScoopInstaller/Scoop.git
   - cd %APPVEYOR_BUILD_FOLDER%
   - ps: Install-Module Pester -Force -SkipPublisherCheck -Scope CurrentUser -RequiredVersion 4.10.1
   - ps: Install-Module BuildHelpers -Force -SkipPublisherCheck -Scope CurrentUser


### PR DESCRIPTION
as v0.2.3 (current) has DLL compatibility issue.
"Add-Type -Path .\Newtonsoft.Json.Schema.dll" causes LoaderExceptions.